### PR TITLE
Add Advising table 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ all_files/
 all_files copy/
 *.xml
 .coverage
+.coveragerc

--- a/queries/all_advisors.sql
+++ b/queries/all_advisors.sql
@@ -1,0 +1,6 @@
+-- Queries all existing Advisors
+--
+-- Since Advisors can't be a FK, i can't do it at ORM level.
+
+select Researcher.* from Researcher
+join Advising on Researcher.lattes_id = Advising.advisor_id;

--- a/tests/ingestion/parsing/test_education.py
+++ b/tests/ingestion/parsing/test_education.py
@@ -102,6 +102,10 @@ class DescribeGraduationOfEducation:
         grad = list(education_from_xml(researcher, document))[0]
         assert grad.course == "Computer Science"
 
+    def has_turing_as_advisor(self, researcher, document):
+        grad = list(education_from_xml(researcher, document))[0]
+        assert grad.advisor == "12345"
+
     def its_starts_at_2014(self, researcher, document):
         grad = list(education_from_xml(researcher, document))[0]
         assert grad.start == 2010
@@ -124,6 +128,10 @@ class DescribeMasterOfEducation:
     def is_ai_course(self, researcher, document):
         master = list(education_from_xml(researcher, document))[1]
         assert master.course == "Artificial Intelligence"
+
+    def has_ada_as_advisor(self, researcher, document):
+        master = list(education_from_xml(researcher, document))[1]
+        assert master.advisor == "67890"
 
     def its_starts_at_2015(self, researcher, document):
         master = list(education_from_xml(researcher, document))[1]
@@ -154,6 +162,10 @@ class DescribePhdOfEducation:
         phd = list(education_from_xml(researcher, document))[2]
         assert phd.category == "DOUTORADO"
 
+    def has_hopper_as_advisor(self, researcher, document):
+        phd = list(education_from_xml(researcher, document))[2]
+        assert phd.advisor == "54321"
+
     def is_data_science_course(self, researcher, document):
         phd = list(education_from_xml(researcher, document))[2]
         assert phd.course == "Data Science"
@@ -178,6 +190,10 @@ class DescribePostdocOfEducation:
             3
         ]
         assert postdoc.category == "POS-DOUTORADO"
+
+    def has_some_advisor(self, researcher, document):
+        postdoc = list(education_from_xml(researcher, document))[3]
+        assert postdoc.advisor == "98765"
 
     def its_starts_at_2022(self, researcher, document):
         postdoc = list(education_from_xml(researcher, document))[

--- a/vitae/features/ingestion/adapters/academic.py
+++ b/vitae/features/ingestion/adapters/academic.py
@@ -33,7 +33,7 @@ class Education:
     institution: Institution
     fields: list[StudyField]
 
-    advisor: str | None = None
+    advisor: str | None
     id: uuid.UUID = field(default_factory=uuid.uuid1)
 
     @property

--- a/vitae/features/ingestion/adapters/academic.py
+++ b/vitae/features/ingestion/adapters/academic.py
@@ -33,6 +33,7 @@ class Education:
     institution: Institution
     fields: list[StudyField]
 
+    advisor: str | None = None
     id: uuid.UUID = field(default_factory=uuid.uuid1)
 
     @property
@@ -46,6 +47,17 @@ class Education:
             course=self.course,
             start=self.start,
             end=self.end,
+        )
+
+    @property
+    def advisor_as_table(self) -> tables.Advisoring | None:
+        if self.advisor is None:
+            return None
+
+        return tables.Advisoring(
+            education_id=self.id,
+            student_id=self.researcher_id,
+            advisor_id=self.advisor,
         )
 
     @property

--- a/vitae/features/ingestion/adapters/academic.py
+++ b/vitae/features/ingestion/adapters/academic.py
@@ -50,11 +50,11 @@ class Education:
         )
 
     @property
-    def advisor_as_table(self) -> tables.Advisoring | None:
+    def advisor_as_table(self) -> tables.Advising | None:
         if not self.advisor:
             return None
 
-        return tables.Advisoring(
+        return tables.Advising(
             education_id=self.id,
             student_id=self.researcher_id,
             advisor_id=self.advisor,

--- a/vitae/features/ingestion/adapters/academic.py
+++ b/vitae/features/ingestion/adapters/academic.py
@@ -51,7 +51,7 @@ class Education:
 
     @property
     def advisor_as_table(self) -> tables.Advisoring | None:
-        if self.advisor is None:
+        if not self.advisor:
             return None
 
         return tables.Advisoring(

--- a/vitae/features/ingestion/parsing/academic.py
+++ b/vitae/features/ingestion/parsing/academic.py
@@ -42,6 +42,7 @@ def education_from_xml(
                         education["nome instituicao"],
                         document,
                     ),
+                    advisor=education["numero id orientador"],
                     fields=list(fields_from_education(education)),
                 )
 

--- a/vitae/features/ingestion/repository.py
+++ b/vitae/features/ingestion/repository.py
@@ -10,7 +10,6 @@ import loguru
 from vitae.features.ingestion.adapters import Curriculum
 from vitae.infra.database import Database
 from vitae.infra.database.transactions import bulk
-from vitae.settings.vitae import Vitae
 
 
 def flatten[T](xs: Iterable[Iterable[T]]) -> Iterable[T]:
@@ -22,6 +21,10 @@ def flatten[T](xs: Iterable[Iterable[T]]) -> Iterable[T]:
 
     """
     return itertools.chain(*xs)
+
+
+def existent[T](xs: Iterable[T | None]) -> list[T]:
+    return [x for x in xs if x is not None]
 
 
 def log_with(into: Path, logger, logfile: str, level: str) -> None:  # noqa: ANN001
@@ -123,6 +126,12 @@ class Researchers:
             fields=flatten(
                 edu.fields_as_table
                 for edu in flatten([cv.education for cv in curricula])
+            ),
+            advisoring=existent(
+                [
+                    edu.advisor_as_table
+                    for edu in flatten([cv.education for cv in curricula])
+                ],
             ),
         )
 

--- a/vitae/features/ingestion/repository.py
+++ b/vitae/features/ingestion/repository.py
@@ -187,6 +187,9 @@ class Researchers:
         academic = bulk.Academic(
             education=(edu.as_table for edu in cv.education),
             fields=flatten(edu.fields_as_table for edu in cv.education),
+            advisoring=existent(
+                [edu.advisor_as_table for edu in cv.education],
+            ),
         )
 
         professional = bulk.Experience(

--- a/vitae/infra/database/tables/__init__.py
+++ b/vitae/infra/database/tables/__init__.py
@@ -1,12 +1,13 @@
 from sqlmodel import SQLModel
 
-from .academic import Education, StudyField
+from .academic import Advisoring, Education, StudyField
 from .institution import Institution
 from .professional import Address, Experience
 from .researcher import Expertise, Nationality, Researcher
 
 __all__ = [
     "Address",
+    "Advisoring",
     "Education",
     "Experience",
     "Expertise",

--- a/vitae/infra/database/tables/__init__.py
+++ b/vitae/infra/database/tables/__init__.py
@@ -1,13 +1,13 @@
 from sqlmodel import SQLModel
 
-from .academic import Advisoring, Education, StudyField
+from .academic import Advising, Education, StudyField
 from .institution import Institution
 from .professional import Address, Experience
 from .researcher import Expertise, Nationality, Researcher
 
 __all__ = [
     "Address",
-    "Advisoring",
+    "Advising",
     "Education",
     "Experience",
     "Expertise",

--- a/vitae/infra/database/tables/academic.py
+++ b/vitae/infra/database/tables/academic.py
@@ -24,7 +24,7 @@ class Education(Orm, table=True):
 
     researcher: "Researcher" = link("education")
     fields: list["StudyField"] = link("education")
-    advisoring: Optional["Advisoring"] = link("education")
+    advisoring: Optional["Advising"] = link("education")
 
 
 class StudyField(Orm, table=True):
@@ -39,7 +39,7 @@ class StudyField(Orm, table=True):
     education: "Education" = link("fields")
 
 
-class Advisoring(Orm, table=True):
+class Advising(Orm, table=True):
     education_id: str = foreign("education.id", primary_key=True)
     student_id: str = foreign("researcher.lattes_id")
     advisor_id: str  # = foreign("researcher.lattes_id")

--- a/vitae/infra/database/tables/academic.py
+++ b/vitae/infra/database/tables/academic.py
@@ -2,7 +2,7 @@
 
 # ruff: noqa: FA102, D101
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .orm import Orm, foreign, key, link, required_key
 
@@ -24,6 +24,7 @@ class Education(Orm, table=True):
 
     researcher: "Researcher" = link("education")
     fields: list["StudyField"] = link("education")
+    advisoring: Optional["Advisoring"] = link("education")
 
 
 class StudyField(Orm, table=True):
@@ -36,3 +37,11 @@ class StudyField(Orm, table=True):
     specialty: str | None
 
     education: "Education" = link("fields")
+
+
+class Advisoring(Orm, table=True):
+    education_id: str = foreign("education.id")
+    student_id: str = foreign("education.researcher_id")
+    advisor_id: str = foreign("researcher.lattes_id")
+
+    education: "Education" = link("advisoring")

--- a/vitae/infra/database/tables/academic.py
+++ b/vitae/infra/database/tables/academic.py
@@ -45,3 +45,5 @@ class Advisoring(Orm, table=True):
     advisor_id: str  # = foreign("researcher.lattes_id")
 
     education: "Education" = link("advisoring")
+    student: "Researcher" = link("student_of", viewonly=True)
+    advisor: "Researcher" = link("advisor_of", viewonly=True)

--- a/vitae/infra/database/tables/academic.py
+++ b/vitae/infra/database/tables/academic.py
@@ -42,6 +42,6 @@ class StudyField(Orm, table=True):
 class Advisoring(Orm, table=True):
     education_id: str = foreign("education.id", primary_key=True)
     student_id: str = foreign("researcher.lattes_id")
-    advisor_id: str = foreign("researcher.lattes_id")
+    advisor_id: str  # = foreign("researcher.lattes_id")
 
     education: "Education" = link("advisoring")

--- a/vitae/infra/database/tables/academic.py
+++ b/vitae/infra/database/tables/academic.py
@@ -40,8 +40,8 @@ class StudyField(Orm, table=True):
 
 
 class Advisoring(Orm, table=True):
-    education_id: str = foreign("education.id")
-    student_id: str = foreign("education.researcher_id")
+    education_id: str = foreign("education.id", primary_key=True)
+    student_id: str = foreign("researcher.lattes_id")
     advisor_id: str = foreign("researcher.lattes_id")
 
     education: "Education" = link("advisoring")

--- a/vitae/infra/database/tables/orm.py
+++ b/vitae/infra/database/tables/orm.py
@@ -21,8 +21,8 @@ class Orm(SQLModel, metaclass=TableNameMeta):  # noqa: D101
     pass
 
 
-def link(back: str) -> Any:
-    return Relationship(back_populates=back)
+def link(back: str, **kargs) -> Any:
+    return Relationship(back_populates=back, sa_relationship_kwargs=kargs)
 
 
 def key(**kargs) -> Any:

--- a/vitae/infra/database/tables/researcher.py
+++ b/vitae/infra/database/tables/researcher.py
@@ -9,7 +9,7 @@ from .orm import Orm, foreign, key, link, required_key
 __all__ = ["Expertise", "Nationality", "Researcher"]
 
 if TYPE_CHECKING:
-    from .academic import Advisoring, Education
+    from .academic import Advising, Education
     from .professional import Address, Experience
 
 
@@ -27,8 +27,8 @@ class Researcher(Orm, table=True):
     expertise: list["Expertise"] = link("researcher")
     experience: list["Experience"] = link("researcher")
     education: list["Education"] = link("researcher")
-    student_of: Optional["Advisoring"] = link("student", viewonly=True)
-    advisor_of: Optional["Advisoring"] = link("advisor", viewonly=True)
+    student_of: Optional["Advising"] = link("student", viewonly=True)
+    advisor_of: Optional["Advising"] = link("advisor", viewonly=True)
 
 
 class Nationality(Orm, table=True):

--- a/vitae/infra/database/tables/researcher.py
+++ b/vitae/infra/database/tables/researcher.py
@@ -2,14 +2,14 @@
 
 # ruff: noqa: FA102, D101
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from .orm import Orm, foreign, key, link, required_key
 
 __all__ = ["Expertise", "Nationality", "Researcher"]
 
 if TYPE_CHECKING:
-    from .academic import Education
+    from .academic import Advisoring, Education
     from .professional import Address, Experience
 
 
@@ -27,6 +27,8 @@ class Researcher(Orm, table=True):
     expertise: list["Expertise"] = link("researcher")
     experience: list["Experience"] = link("researcher")
     education: list["Education"] = link("researcher")
+    student_of: Optional["Advisoring"] = link("student", viewonly=True)
+    advisor_of: Optional["Advisoring"] = link("advisor", viewonly=True)
 
 
 class Nationality(Orm, table=True):

--- a/vitae/infra/database/transactions/bulk.py
+++ b/vitae/infra/database/transactions/bulk.py
@@ -8,12 +8,13 @@ and send to database.
 # ruff: noqa: D101, D105
 
 from collections.abc import Iterable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from sqlmodel import SQLModel
 
 from vitae.infra.database.tables import (
     Address,
+    Advisoring,
     Education,
     Experience,
     Expertise,
@@ -50,10 +51,12 @@ class Researchers(Transaction):
 class Academic(Transaction):
     education: Iterable[Education]
     fields: Iterable[StudyField]
+    advisoring: Iterable[Advisoring] = field(default_factory=list)
 
     def __iter__(self) -> Iterator[SQLModel]:
         yield from self.education
         yield from self.fields
+        yield from self.advisoring
 
 
 @dataclass

--- a/vitae/infra/database/transactions/bulk.py
+++ b/vitae/infra/database/transactions/bulk.py
@@ -14,7 +14,7 @@ from sqlmodel import SQLModel
 
 from vitae.infra.database.tables import (
     Address,
-    Advisoring,
+    Advising,
     Education,
     Experience,
     Expertise,
@@ -51,7 +51,7 @@ class Researchers(Transaction):
 class Academic(Transaction):
     education: Iterable[Education]
     fields: Iterable[StudyField]
-    advisoring: Iterable[Advisoring] = field(default_factory=list)
+    advisoring: Iterable[Advising] = field(default_factory=list)
 
     def __iter__(self) -> Iterator[SQLModel]:
         yield from self.education

--- a/vitae/infra/database/transactions/bulk.py
+++ b/vitae/infra/database/transactions/bulk.py
@@ -51,7 +51,7 @@ class Researchers(Transaction):
 class Academic(Transaction):
     education: Iterable[Education]
     fields: Iterable[StudyField]
-    advisoring: Iterable[Advising] = field(default_factory=list)
+    advisoring: Iterable[Advising]
 
     def __iter__(self) -> Iterator[SQLModel]:
         yield from self.education


### PR DESCRIPTION

## At A Glance

![Schema v2 1 - 2025-06-28](https://github.com/user-attachments/assets/d63ea679-8d68-4469-8681-9f79c8242aeb)

## What I've done

I created the table `Advising` and its relationship,
also adapted Schemas to support it.

My initial idea was to put `advisor` as a field in Education and `advisings` of Researcher, but I had problems with the ORM conflicting fields. So I choose this approach.

---
This time, I uploaded the PNG version since the SVG is larger than 10MB (~12Mb).
