### PR TITLE
Also add Study Field from complementary information

### DIFF
--- a/tests/ingestion/parsing/test_education.py
+++ b/tests/ingestion/parsing/test_education.py
@@ -80,6 +80,16 @@ def document() -> Node:
             </POS-DOUTORADO>
         </FORMACAO-ACADEMICA-TITULACAO>
         </DADOS-GERAIS>
+        <DADOS-COMPLEMENTARES>
+            <INFORMACOES-ADICIONAIS-CURSOS>
+                <INFORMACAO-ADICIONAL-CURSO CODIGO-CURSO="101" 
+                    NOME-GRANDE-AREA-DO-CONHECIMENTO="Ciências Exatas" 
+                    NOME-DA-AREA-DO-CONHECIMENTO="Ciência da Computação" 
+                    NOME-DA-SUB-AREA-DO-CONHECIMENTO="" 
+                    NOME-DA-ESPECIALIDADE=""
+                />
+            </INFORMACOES-ADICIONAIS-CURSOS>
+        </DADOS-COMPLEMENTARES>
         """).as_node
 
 
@@ -118,6 +128,16 @@ class DescribeGraduationOfEducation:
         grad = list(education_from_xml(researcher, document))[0]
         assert grad.institution.lattes_id == "UNI001"
         assert grad.institution.name == "Tech University"
+
+    def is_cs_field(self, researcher, document):
+        grad = list(education_from_xml(researcher, document))[0]
+        field = grad.fields[0]
+
+        assert field.major == "Ciências Exatas"
+        assert field.area == "Ciência da Computação"
+        assert field.sub == None
+        assert field.specialty == None
+
 
 
 class DescribeMasterOfEducation:


### PR DESCRIPTION
## In Summary

Now, `StudyField` is also parsed from complementary information about the target course,
since some education nodes doesn't provide this information.

## In Details

I've noticed that `StudyField` was significantly smaller than other tables, so I decided to investigate it better.

Basically, some education nodes won't provide `AREAS-DE-CONHECIMENTO` child node and instead, will have the Study Field into `INFORMACOES-ADICIONAIS-CURSOS`.

### Structure

An Education field has the following structure:

```xml
<DADOS-GERAIS>
  <FORMACAO-ACADEMICA-TITULACAO>
    <GRADUACAO CODIGO-CURSO="101" ... />
    <MESTRADO CODIGO-CURSO="201" ... >
      <AREAS-DO-CONHECIMENTO>
        <AREA-DO-CONHECIMENTO-1 {{StudyField}} />
        <AREA-DO-CONHECIMENTO-2  {{StudyField}} />
      </AREAS-DO-CONHECIMENTO>
      ...
    </MESTRADO>
    ...
  </FORMACAO-ACADEMICA-TITULACAO>
</DADOS-GERAIS>
```

But, when some `Education` has not `AREAS-DO-CONHECIMENTO`, we need to fetch this information from other node outside `DADOS-GERAIS`.

I found that this information is found into `INFORMACOES-ADICIONAIS-CURSOS`, with the following structure:

```xml
<DADOS-GERAIS>
  ...
</DADOS-GERAIS>
<DADOS-COMPLEMENTARES>
  <INFORMACOES-ADICIONAIS-CURSOS>
    <INFORMACAO-ADICIONAL-CURSO CODIGO-CURSO="101" ... {{StudyField}} />
  </INFORMACOES-ADICIONAIS-CURSOS>
</DADOS-COMPLEMENTARES>
```