### PR TITLE
Implement pagination for Researchers

### DIFF
--- a/vitae/features/researchers/repository/researchers.py
+++ b/vitae/features/researchers/repository/researchers.py
@@ -80,6 +80,8 @@ class Researchers(Protocol):
     def by_name(
         self,
         name: str,
+        n: int,
+        page: int,
         order_by: Order,
         filter_by: ChoosenFilters | None,
     ) -> Iterable[Researcher]: ...
@@ -87,6 +89,8 @@ class Researchers(Protocol):
     def stricly_by_name(
         self,
         name: str,
+        n: int,
+        page: int,
         order_by: Order,
         filter_by: ChoosenFilters | None,
     ) -> Iterable[Researcher]: ...
@@ -121,6 +125,7 @@ class ResearchersInDatabase(Researchers):
         self,
         name: str,
         n: int = 50,
+        page: int = 1,
         order_by: Order = None,
         filter_by: ChoosenFilters | None = None,
     ) -> Iterable[Researcher]:
@@ -156,6 +161,7 @@ class ResearchersInDatabase(Researchers):
 
         """
         has_name = col(tables.Researcher.full_name).ilike(f"%{name}%")
+        offset = n * (page - 1)
 
         with self.database.session as session:
             selected = select(tables.Researcher).where(
@@ -163,7 +169,7 @@ class ResearchersInDatabase(Researchers):
             )
             filtered = using_filter(selected, filter_by)
             ordered = ordered_by_name(filtered, order_by)
-            limited = ordered.limit(n)
+            limited = ordered.offset(offset).limit(n)
 
             result: list[tables.Researcher] = session.exec(limited).all()  # type: ignore
             return [Researcher.from_table(r) for r in result]
@@ -172,6 +178,7 @@ class ResearchersInDatabase(Researchers):
         self,
         name: str,
         n: int = 50,
+        page: int = 1,
         order_by: Order = None,
         filter_by: ChoosenFilters | None = None,
     ) -> Iterable[Researcher]:
@@ -202,6 +209,7 @@ class ResearchersInDatabase(Researchers):
 
         """
         each_name = name.split()
+        offset = n * (page - 1)
 
         has_names = [
             col(tables.Researcher.full_name).ilike(f"%{name_token}%")
@@ -214,7 +222,7 @@ class ResearchersInDatabase(Researchers):
             )
             filtered = using_filter(selected, filter_by)
             ordered = ordered_by_name(filtered, order_by)
-            limited = ordered.limit(n)
+            limited = ordered.offset(offset).limit(n)
 
             result: list[tables.Researcher] = session.exec(limited).all()  # type: ignore
             return [Researcher.from_table(r) for r in result]

--- a/vitae/features/researchers/repository/researchers.py
+++ b/vitae/features/researchers/repository/researchers.py
@@ -80,7 +80,7 @@ class Researchers(Protocol):
     def by_name(
         self,
         name: str,
-        n: int,
+        researchers: int,
         page: int,
         order_by: Order,
         filter_by: ChoosenFilters | None,
@@ -89,7 +89,7 @@ class Researchers(Protocol):
     def stricly_by_name(
         self,
         name: str,
-        n: int,
+        researchers: int,
         page: int,
         order_by: Order,
         filter_by: ChoosenFilters | None,
@@ -124,7 +124,7 @@ class ResearchersInDatabase(Researchers):
     def stricly_by_name(
         self,
         name: str,
-        n: int = 50,
+        researchers: int = 50,
         page: int = 1,
         order_by: Order = None,
         filter_by: ChoosenFilters | None = None,
@@ -161,7 +161,7 @@ class ResearchersInDatabase(Researchers):
 
         """
         has_name = col(tables.Researcher.full_name).ilike(f"%{name}%")
-        offset = n * (page - 1)
+        offset = researchers * (page - 1)
 
         with self.database.session as session:
             selected = select(tables.Researcher).where(
@@ -169,7 +169,7 @@ class ResearchersInDatabase(Researchers):
             )
             filtered = using_filter(selected, filter_by)
             ordered = ordered_by_name(filtered, order_by)
-            limited = ordered.offset(offset).limit(n)
+            limited = ordered.offset(offset).limit(researchers)
 
             result: list[tables.Researcher] = session.exec(limited).all()  # type: ignore
             return [Researcher.from_table(r) for r in result]
@@ -177,7 +177,7 @@ class ResearchersInDatabase(Researchers):
     def by_name(
         self,
         name: str,
-        n: int = 50,
+        researchers: int = 50,
         page: int = 1,
         order_by: Order = None,
         filter_by: ChoosenFilters | None = None,
@@ -209,7 +209,7 @@ class ResearchersInDatabase(Researchers):
 
         """
         each_name = name.split()
-        offset = n * (page - 1)
+        offset = researchers * (page - 1)
 
         has_names = [
             col(tables.Researcher.full_name).ilike(f"%{name_token}%")
@@ -222,7 +222,7 @@ class ResearchersInDatabase(Researchers):
             )
             filtered = using_filter(selected, filter_by)
             ordered = ordered_by_name(filtered, order_by)
-            limited = ordered.offset(offset).limit(n)
+            limited = ordered.offset(offset).limit(researchers)
 
             result: list[tables.Researcher] = session.exec(limited).all()  # type: ignore
             return [Researcher.from_table(r) for r in result]

--- a/vitae/features/researchers/routes.py
+++ b/vitae/features/researchers/routes.py
@@ -50,6 +50,7 @@ def home(
                 "expertise": None,
             },
             "order": None,
+            "page": 1,
         },
     )
 
@@ -58,6 +59,7 @@ def home(
 def show_search(
     request: Request,
     query: str = "",
+    page: int = 1,
     sort: str | None = None,
     country: str | None = None,
     state: str | None = None,
@@ -95,6 +97,7 @@ def show_search(
             "query": query,
             "choosen_filters": choosen_filters,
             "order": sort,
+            "page": page,
         },
     )
 

--- a/vitae/features/researchers/routes.py
+++ b/vitae/features/researchers/routes.py
@@ -46,7 +46,7 @@ def home(
                 "country": None,
                 "state": None,
                 "started": None,
-                "has_finished": None,
+                "has_finished": False,
                 "expertise": None,
             },
             "order": None,
@@ -62,7 +62,7 @@ def show_search(
     country: str | None = None,
     state: str | None = None,
     started: str | None = None,
-    has_finished: bool | None = None,
+    has_finished: bool = False,
     expertise: str | None = None,
 ):
     # Requirements Setup

--- a/vitae/features/researchers/routes.py
+++ b/vitae/features/researchers/routes.py
@@ -86,6 +86,7 @@ def show_search(
         query,
         order_by=SortingOrder(sort) if sort else None,
         filter_by=choosen_filters,
+        page=page,
     )
 
     return templates.TemplateResponse(

--- a/vitae/features/researchers/templates/base.html
+++ b/vitae/features/researchers/templates/base.html
@@ -7,10 +7,19 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">  
 </head>
-<body class="bg-gradient-to-br from-indigo-500 to-purple-600 min-h-screen font-sans text-gray-800">
+<body class="bg-gradient-to-br from-indigo-500 to-purple-600 min-h-screen font-sans text-gray-800" id="top">
   <div class="max-w-screen-xl mx-auto px-4 py-6">
     {% include "components/header.html" %}
     {% block content %}{% endblock %}
   </div>
+  <a href="#top" id="goUpBtn" class="hidden fixed bottom-5 right-5 z-50 bg-white text-purple-600 px-4 py-2 rounded hover:bg-gray-100">
+    ↑
+  </a>
+  <script>
+    const btn = document.getElementById("goUpBtn");
+    window.addEventListener("scroll", () => {
+      btn.classList.toggle("hidden", window.scrollY <= 300);
+    });
+  </script>
 </body>
 </html>

--- a/vitae/features/researchers/templates/base.html
+++ b/vitae/features/researchers/templates/base.html
@@ -17,6 +17,14 @@
     class="hidden fixed bottom-5 right-5 z-50 bg-white text-purple-600 w-12 h-12 flex items-center justify-center rounded hover:bg-gray-100">
     ↑
   </a>
+
+  {% if page > 1 %}
+  <a href="javascript:void(0)" onclick="history.back()"
+    class="fixed bottom-5 left-5 z-50 bg-white text-purple-600 w-12 h-12 flex items-center justify-center rounded hover:bg-gray-100">
+    ←
+  </a>
+  {% endif %}
+
   <script>
     const btn = document.getElementById("goUpBtn");
     window.addEventListener("scroll", () => {

--- a/vitae/features/researchers/templates/base.html
+++ b/vitae/features/researchers/templates/base.html
@@ -12,7 +12,9 @@
     {% include "components/header.html" %}
     {% block content %}{% endblock %}
   </div>
-  <a href="#top" id="goUpBtn" class="hidden fixed bottom-5 right-5 z-50 bg-white text-purple-600 px-4 py-2 rounded hover:bg-gray-100">
+
+  <a href="#top" id="goUpBtn"
+    class="hidden fixed bottom-5 right-5 z-50 bg-white text-purple-600 w-12 h-12 flex items-center justify-center rounded hover:bg-gray-100">
     ↑
   </a>
   <script>

--- a/vitae/features/researchers/templates/base.html
+++ b/vitae/features/researchers/templates/base.html
@@ -13,7 +13,7 @@
     {% block content %}{% endblock %}
   </div>
 
-  <a href="#top" id="goUpBtn"
+  <a href="#top" id="go-top"
     class="hidden fixed bottom-5 right-5 z-50 bg-white text-purple-600 w-12 h-12 flex items-center justify-center rounded hover:bg-gray-100">
     ↑
   </a>
@@ -26,7 +26,7 @@
   {% endif %}
 
   <script>
-    const btn = document.getElementById("goUpBtn");
+    const btn = document.getElementById("go-top");
     window.addEventListener("scroll", () => {
       btn.classList.toggle("hidden", window.scrollY <= 300);
     });

--- a/vitae/features/researchers/templates/search.html
+++ b/vitae/features/researchers/templates/search.html
@@ -7,7 +7,12 @@
 
   <div class="bg-white/90 backdrop-blur rounded-2xl shadow-md p-6 min-h-[600px]">
     <div class="flex justify-between items-center mb-6 border-b border-gray-100 pb-4">
-      <div class="text-gray-600 text-base">{{ results|length }} pesquisadores encontrados</div>
+      <h3 class="text-gray-600 font-semibold mb-2">Página {{ page }}</h3>
+      {% if results|length %}
+      <h4 class="text-gray-600 text-base font-semibold mb-2">
+        {{ results|length }} pesquisadores encontrados para esta página.
+      </h4>
+      {% endif %}
       <select class="px-3 py-2 border-2 border-gray-200 rounded-md text-sm" id="sort-select" name="sort" form="filters-form">
         <option value="" {% if not order %}selected{% endif %}>Ordenar...</option>
         <option value="asc" {% if order == 'asc' %}selected{% endif %}>A-Z</option>
@@ -29,7 +34,10 @@
       </div>
     {% else %}
       <div class="text-center py-24 text-gray-600">
-        <h3 class="text-lg font-semibold mb-2">Nenhum pesquisador encontrado.</h3>
+        <h3 class="text-lg font-semibold mb-2">Página {{ page }}</h3>
+        <h4 class="text-lg font-semibold mb-2">
+          Nenhum pesquisador encontrado para esta página. 
+        </h4>
       </div>
     {% endif %}
   </div>

--- a/vitae/features/researchers/templates/search.html
+++ b/vitae/features/researchers/templates/search.html
@@ -9,9 +9,14 @@
     <div class="flex justify-between items-center mb-6 border-b border-gray-100 pb-4">
       <h3 class="text-gray-600 font-semibold mb-2">Página {{ page }}</h3>
       {% if results|length %}
-      <h4 class="text-gray-600 text-base font-semibold mb-2">
-        {{ results|length }} pesquisadores encontrados para esta página.
-      </h4>
+        <h4 class="text-gray-600 text-base font-semibold mb-2">
+          {{ results|length }}
+          {% if results|length == 1 %}
+            pesquisador encontrado para esta página.
+          {% else %}
+            pesquisadores encontrados para esta página.
+          {% endif %}
+        </h4>
       {% endif %}
       <select class="px-3 py-2 border-2 border-gray-200 rounded-md text-sm" id="sort-select" name="sort" form="filters-form">
         <option value="" {% if not order %}selected{% endif %}>Ordenar...</option>

--- a/vitae/features/researchers/templates/search.html
+++ b/vitae/features/researchers/templates/search.html
@@ -19,6 +19,14 @@
       {% for researcher in results %}
         {% include "components/researcher_card.html" %}
       {% endfor %}
+      <div class="flex justify-center mt-8">
+        <nav class="inline-flex -space-x-px">
+            <a href="?query={{ query }}&sort={{ order }}&country={{ choosen_filters.country }}&state={{ choosen_filters.state }}&started={{ choosen_filters.started }}&has_finished={{ choosen_filters.has_finished }}&expertise={{ choosen_filters.expertise }}&page={{ page + 1 }}" 
+              class="px-3 py-1 border rounded-l bg-gray-100 hover:bg-gray-200">
+                Carregar mais
+            </a>
+        </nav>
+      </div>
     {% else %}
       <div class="text-center py-24 text-gray-600">
         <h3 class="text-lg font-semibold mb-2">Nenhum pesquisador encontrado.</h3>

--- a/vitae/features/researchers/usecases/search.py
+++ b/vitae/features/researchers/usecases/search.py
@@ -32,6 +32,7 @@ class SearchResearchers:
         *,
         order_by: SortingOrder | None = None,
         filter_by: ChoosenFilters | None = None,
+        page: int = 1,
     ) -> list[Researcher]:
         if is_lattes_id(query):
             result = self.researchers.by_id(query)
@@ -42,6 +43,7 @@ class SearchResearchers:
                 query,
                 order_by=order_by.value if order_by else None,
                 filter_by=filter_by,
+                page=page,
             ),
         )
 


### PR DESCRIPTION
This PR implements pagination for allow database lazy loading. This improves the UX and also the application performance, since we don't need to fetch the whole database every single time.

## UX improvements
- [x] Added Load-more button
- [x] Fit labels to this implementation 
- [x] Added Go-top button
- [x] Added Go-back button for new pages

### Details

#### Go-Top button

This button appears automatically when user scroll.

<img width="289" height="175" alt="image" src="https://github.com/user-attachments/assets/3d9d2e2f-a294-476e-aa6c-6acdbd40fcca" />

#### Go-Back button

This button appears when user loads a new page.

<img width="762" height="808" alt="image" src="https://github.com/user-attachments/assets/48531cfb-da30-4940-946a-398ec9c2aac3" />

#### Updated Labels

When Researchers are found:

<img width="1115" height="119" alt="image" src="https://github.com/user-attachments/assets/5bcdd014-620b-4f80-9cf7-3b7035fa2c0a" />

No Researchers found:

<img width="1868" height="1027" alt="image" src="https://github.com/user-attachments/assets/9832f1bb-cabd-4321-8eea-561d19572860" />

#### Load-More button

<img width="1164" height="164" alt="image" src="https://github.com/user-attachments/assets/9a75b370-8da7-424a-90fe-bda8b970b817" />

## Repository
The changes were minimal, adding more parameters to the repository and leaving the offset rules with him.

---

## Additional Questions

#### **Why not use Bootstrap-like Pagination?**
Bootstrap-like pagination would require me search the whole database to know before-hand how many pages are needed for that query.

This is something I'm avoiding to do. Instead, I search each 50 Researchers only. And if needed, request more 50.

---

- Closes #40